### PR TITLE
Fmsd 97 volume modal close on escape

### DIFF
--- a/src/components/FilesHandler/VolumeManage/ManageVolumesModal.tsx
+++ b/src/components/FilesHandler/VolumeManage/ManageVolumesModal.tsx
@@ -150,6 +150,21 @@ const ManageVolumesModal = ({ modalDisplay }: ManageModalProps): ReactElement =>
     }
   }, [beeApi, isNewVolumeCreated, setIsNewVolumeCreated])
 
+  // Escape will close the modal
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        modalDisplay(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleEscKey)
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey)
+    }
+  }, [modalDisplay])
+
   return (
     <div className={classesGlobal.modal}>
       <div className={classesGlobal.modalContainer}>


### PR DESCRIPTION
**Description**
Adds feature that Escape can also close the volume management modal.

**Changes** Made
 - adds a useEffect to `ManageVolumesModal`

**How Has This Been Tested?**
it was manually tested.