### PR TITLE
Bug: Admin Drive purchase

### DIFF
--- a/src/modules/filemanager/constants/stamps.ts
+++ b/src/modules/filemanager/constants/stamps.ts
@@ -1,5 +1,5 @@
 export const desiredLifetimeOptions = [
-  { value: 0, label: 'Select a value' },
+  { value: -1, label: 'Select a value' },
   { value: 1, label: '1 week' },
   { value: 2, label: '1 month' },
   { value: 3, label: '3 months' },


### PR DESCRIPTION
🔖 Title
Validation for Admin Stamp creation - disable “Purchase” until desired lifetime is selected

📝 Description

This pull request addresses a UX and validation issue in the Admin Stamp creation modal, where users could click the 'Purchase Stamp & Create Drive' button without selecting a desired lifetime. This caused invalid or incomplete initialization requests and left the admin status bas stuck in a loading state.

Changes:
- Set default lifetimeIndex to -1 (no selection state).
- Added formError state to display inline validation messages.
- Prevented drive creation when no lifetime is selected.
- Added conditional logic to compute validity date only when a lifetime is chosen.
- Displayed placeholder '—' for cost when no lifetime is selected.
- Updated desiredLifetimeOptions to use { value: -1, label: 'Select a value' }.

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-678

🧪 How Has This Been Tested?
✅ Manually tested with Chrome

✅ Checklist
✅ I have performed a self-review of my code