### PR TITLE
Bug-fix/spdv 684 upload multiple files

### DIFF
--- a/src/modules/filemanager/components/FileBrowser/FileBrowser.tsx
+++ b/src/modules/filemanager/components/FileBrowser/FileBrowser.tsx
@@ -169,8 +169,8 @@ export function FileBrowser(): ReactElement {
   return (
     <>
       {conflictPortal}
-      <input type="file" ref={legacyUploadRef} style={{ display: 'none' }} onChange={onFileSelected} />
-      <input type="file" ref={bulk.fileInputRef} style={{ display: 'none' }} onChange={onFileSelected} />
+      <input type="file" ref={legacyUploadRef} style={{ display: 'none' }} onChange={onFileSelected} multiple />
+      <input type="file" ref={bulk.fileInputRef} style={{ display: 'none' }} onChange={onFileSelected} multiple />
 
       <div className="fm-file-browser-container" data-search-mode={isSearchMode ? 'true' : 'false'}>
         <FileBrowserTopBar />
@@ -262,7 +262,7 @@ export function FileBrowser(): ReactElement {
                     <ContextMenu>
                       <div className="fm-context-item">New folder</div>
                       <div className="fm-context-item" onClick={onContextUploadFile}>
-                        Upload file
+                        Upload file(s)
                       </div>
                       <div className="fm-context-item">Upload folder</div>
                       <div className="fm-context-item-border" />


### PR DESCRIPTION
🔖 Title
Enable multi-file upload from context menu - align Upload button behaviour with drag & drop

📝 Description

This change enables multi-file selection in the system file picker, allowing users to select and upload multiple files in one action matching standard file manager behaviour and improving consistency across upload methods.

Changes
- Updated the upload handler to process multiple files in one batch using the existing uploadFiles() function.

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-684

🧪 How Has This Been Tested?
✅ Manually tested with Chrome

✅ Checklist
✅ I have performed a self-review of my code