### PR TITLE
Bug-fix/spdv 682 disable folder options

### DIFF
--- a/src/modules/filemanager/components/FileBrowser/FileBrowser.tsx
+++ b/src/modules/filemanager/components/FileBrowser/FileBrowser.tsx
@@ -260,11 +260,15 @@ export function FileBrowser(): ReactElement {
 
                   return (
                     <ContextMenu>
-                      <div className="fm-context-item">New folder</div>
+                      <div className="fm-context-item" style={{ display: 'none' }}>
+                        New folder
+                      </div>
                       <div className="fm-context-item" onClick={onContextUploadFile}>
                         Upload file
                       </div>
-                      <div className="fm-context-item">Upload folder</div>
+                      <div className="fm-context-item" style={{ display: 'none' }}>
+                        Upload folder
+                      </div>
                       <div className="fm-context-item-border" />
                       <div className="fm-context-item">Paste</div>
                       <div className="fm-context-item-border" />


### PR DESCRIPTION
🔖 Title
Hide inactive 'New Folder' and 'Upload Folder' options in right-click context menu

📝 Description

This pull request makes a small UI adjustment to the File Manager’s right-click context menu by hiding placeholder actions that are not yet implemented. 

Changes:
- Set inline style display: 'none' for the 'New Folder' and 'Upload Folder' context menu items

🔗 Related Issues
https://solar-punk.atlassian.net/browse/SPDV-682

🧪 How Has This Been Tested?
✅ Manually tested with Chrome

✅ Checklist
✅ I have performed a self-review of my code