### PR TITLE
fix: consume gift wallet fees as decimal strings

### DIFF
--- a/src/pages/giftCode/index.tsx
+++ b/src/pages/giftCode/index.tsx
@@ -52,8 +52,8 @@ export default function Index(): ReactElement | null {
     )
   }
 
-  const GIFT_WALLET_FUND_DAI_AMOUNT = DAI.fromWei(giftWalletFees.dai)
-  const GIFT_WALLET_FUND_BZZ_AMOUNT = BZZ.fromPLUR(giftWalletFees.bzz)
+  const GIFT_WALLET_FUND_DAI_AMOUNT = DAI.fromDecimalString(giftWalletFees.dai)
+  const GIFT_WALLET_FUND_BZZ_AMOUNT = BZZ.fromDecimalString(giftWalletFees.bzz)
 
   async function onCreate() {
     enqueueSnackbar('Sending funds to gift wallet...')


### PR DESCRIPTION
  - The `giftWalletFees` prop passes `bzz` and `dai` values as human-readable
    decimal strings (e.g. `"0.5"`, `"0.1"`), not raw Wei/PLUR integers.
  - Replaces `DAI.fromWei()` and `BZZ.fromPLUR()` with `DAI.fromDecimalString()`
    and `BZZ.fromDecimalString()` so the amounts are parsed correctly.