### PR TITLE
fix: spdv-1048

### DIFF
--- a/src/providers/Settings.tsx
+++ b/src/providers/Settings.tsx
@@ -101,6 +101,15 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
     setBeeApiState()
   }, [config, apiUrl])
 
+  useEffect(() => {
+    if (!isDesktop || !config?.['blockchain-rpc-endpoint']) return
+
+    const daemonRpcUrl = config['blockchain-rpc-endpoint']
+    localStorage.setItem(LocalStorageKeys.providerUrl, daemonRpcUrl)
+    setRpcProviderUrl(daemonRpcUrl)
+    setRpcProvider(newGnosisProvider(daemonRpcUrl))
+  }, [isDesktop, config])
+
   const updateApiUrl = useCallback((url: string) => {
     const userProvidedUrl = makeHttpUrl(url)
 


### PR DESCRIPTION
https://solar-punk.atlassian.net/browse/SPDV-1048

To test the changes properly:

- Change the blockchain RPC url to an invalid value. E.g: http://localhost:9999
- Delete the blockchain RPC endpoint related field from the browser's local storage
- Refresh the page
- You should see the previously set RPC endpoint value
- Repeat the steps with a correct value. E.g: https://xdai.fairdatasociety.org