### PR TITLE
fix: broken Bee docs link in Upload postage stamp panel

### DIFF
--- a/src/pages/files/Upload.tsx
+++ b/src/pages/files/Upload.tsx
@@ -181,7 +181,7 @@ export function Upload(): ReactElement {
             <DocumentationText>
               Please refer to the{' '}
               <a
-                href="https://docs.ethswarm.org/debug-api/#tag/Postage-Stamps/paths/~1stamps~1{amount}~1{depth}/post"
+                href="https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1{amount}~1{depth}/post"
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
The "official Bee documentation" link pointed to docs.ethswarm.org/**debug-api**/ which now returns 404. Updated to docs.ethswarm.org/**api**/ which serves the current postage stamps endpoint API reference.
SPDV-1262