### PR TITLE
ci: skip release-please job in forks (SPDV-1274)

### DIFF
--- a/.github/workflows/release_github.yaml
+++ b/.github/workflows/release_github.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Only run releases in the upstream repo, not in forks (fork lacks the GHA_PAT_BASIC secret)
+    if: github.repository == 'ethersphere/bee-dashboard'
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         id: release


### PR DESCRIPTION
The **Release Github** workflow runs `release-please` on every push to master and fails in this fork with Input required and not supplied: token — the `GHA_PAT_BASIC` secret only exists upstream, and we don't cut releases here.

 Added a job-level guard so it runs only on `ethersphere/bee-dashboard`. In the fork the job now skips (run shows green) instead of failing; upstream behavior is unchanged.

SPDV-1274