### PR TITLE
fix: clarify postage stamp Capacity label (used / total)

### DIFF
--- a/src/modules/filemanager/components/Sidebar/DriveItem/DriveItem.tsx
+++ b/src/modules/filemanager/components/Sidebar/DriveItem/DriveItem.tsx
@@ -382,7 +382,7 @@ function DriveItemComponent({ drive, stamp, isSelected, setErrorMessage }: Drive
         <div className="fm-drive-item-content">
           <div className={capacityClassName}>
             <span>
-              Capacity <ProgressBar value={capacityPct} width="64px" /> {usedSize} / {stampSize}
+              Capacity (Used / Total) <ProgressBar value={capacityPct} width="64px" /> {usedSize} / {stampSize}
             </span>
             <Tooltip
               label={

--- a/src/pages/stamps/StampsTable.tsx
+++ b/src/pages/stamps/StampsTable.tsx
@@ -38,7 +38,7 @@ function StampsTable({ postageStamps }: Props): ReactElement | null {
               <ExpandableListItemKey label="Batch ID" value={stamp.batchID.toHex()} />
               <ExpandableListItem label="Depth" value={String(stamp.depth)} />
               <ExpandableListItem
-                label="Capacity"
+                label="Capacity (Used / Total)"
                 value={`${getHumanReadableFileSize(stamp.size.toBytes() - stamp.remainingSize.toBytes())} / ${getHumanReadableFileSize(
                   stamp.size.toBytes(),
                 )}`}


### PR DESCRIPTION
Rename the ambiguous "Capacity" label to "**Capacity (Used / Total)**" so it's clear the value shown is used vs. total effective capacity. Applies to the Stamps page (StampsTable) and the file-manager drive item (DriveItem).

Closes #677