### PR TITLE
Fix: stamp purchase errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "check:types": "tsc --project tsconfig.lib.json",
     "update-map-data": "node ./utils/update-map-data.js",
     "mock:bee": "node ./utils/mock-bee-proxy.js",
+    "mock:bee:nofunds": "STATUS=400 MESSAGE='out of funds' node ./utils/mock-bee-proxy.js",
+    "mock:bee:poor": "POOR_WALLET=1 node ./utils/mock-bee-proxy.js",
     "init:husky": "pnpm husky install"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:fix": "pnpm run lint --fix",
     "check:types": "tsc --project tsconfig.lib.json",
     "update-map-data": "node ./utils/update-map-data.js",
+    "mock:bee": "node ./utils/mock-bee-proxy.js",
     "init:husky": "pnpm husky install"
   },
   "peerDependencies": {

--- a/src/pages/stamps/PostageStampAdvancedCreation.tsx
+++ b/src/pages/stamps/PostageStampAdvancedCreation.tsx
@@ -17,6 +17,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as StampsContext } from '../../providers/Stamps'
 import { ROUTES } from '../../routes'
 import { secondsToTimeString } from '../../utils'
+import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '../../utils/bee-error'
 import { getHumanReadableFileSize } from '../../utils/file'
 import { validateDepthInput } from '../../utils/stamp'
 
@@ -49,7 +50,7 @@ const useStyles = makeStyles()(() => ({
 
 export function PostageStampAdvancedCreation({ onFinished }: Props): ReactElement {
   const { classes } = useStyles()
-  const { chainState } = useContext(BeeContext)
+  const { chainState, walletBalance } = useContext(BeeContext)
   const { refresh } = useContext(StampsContext)
   const { beeApi } = useContext(SettingsContext)
 
@@ -102,9 +103,18 @@ export function PostageStampAdvancedCreation({ onFinished }: Props): ReactElemen
     let success = false
 
     try {
-      setSubmitting(true)
       const amount = BigInt(amountInput)
       const depth = Number.parseInt(depthInput)
+
+      const fundsShortage = getStampFundsShortageMessage(Utils.getStampCost(depth, amount), walletBalance)
+
+      if (fundsShortage) {
+        enqueueSnackbar(fundsShortage, { variant: 'error' })
+
+        return
+      }
+
+      setSubmitting(true)
       const options: PostageBatchOptions = {
         waitForUsable: false,
         label: labelInput || undefined,
@@ -117,7 +127,7 @@ export function PostageStampAdvancedCreation({ onFinished }: Props): ReactElemen
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e)
-      enqueueSnackbar(`Error: ${(e as Error).message}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to buy postage stamp: ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
     } finally {
       setSubmitting(false)
     }

--- a/src/pages/stamps/PostageStampAdvancedCreation.tsx
+++ b/src/pages/stamps/PostageStampAdvancedCreation.tsx
@@ -17,7 +17,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as StampsContext } from '../../providers/Stamps'
 import { ROUTES } from '../../routes'
 import { secondsToTimeString } from '../../utils'
-import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '../../utils/bee-error'
+import { extractBeeApiErrorMessage, notifyStampFundsShortage } from '../../utils/bee-error'
 import { getHumanReadableFileSize } from '../../utils/file'
 import { validateDepthInput } from '../../utils/stamp'
 
@@ -106,11 +106,7 @@ export function PostageStampAdvancedCreation({ onFinished }: Props): ReactElemen
       const amount = BigInt(amountInput)
       const depth = Number.parseInt(depthInput)
 
-      const fundsShortage = getStampFundsShortageMessage(Utils.getStampCost(depth, amount), walletBalance)
-
-      if (fundsShortage) {
-        enqueueSnackbar(fundsShortage, { variant: 'error' })
-
+      if (notifyStampFundsShortage(Utils.getStampCost(depth, amount), walletBalance, enqueueSnackbar)) {
         return
       }
 

--- a/src/pages/stamps/PostageStampStandardCreation.tsx
+++ b/src/pages/stamps/PostageStampStandardCreation.tsx
@@ -13,7 +13,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as StampsContext } from '../../providers/Stamps'
 import { ROUTES } from '../../routes'
 import { secondsToTimeString } from '../../utils'
-import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '../../utils/bee-error'
+import { extractBeeApiErrorMessage, notifyStampFundsShortage } from '../../utils/bee-error'
 import { validateDepthInput } from '../../utils/stamp'
 
 interface Props {
@@ -111,11 +111,7 @@ export function PostageStampStandardCreation({ onFinished }: Props): ReactElemen
     let success = false
 
     try {
-      const fundsShortage = getStampFundsShortageMessage(Utils.getStampCost(depthInput, amountInput), walletBalance)
-
-      if (fundsShortage) {
-        enqueueSnackbar(fundsShortage, { variant: 'error' })
-
+      if (notifyStampFundsShortage(Utils.getStampCost(depthInput, amountInput), walletBalance, enqueueSnackbar)) {
         return
       }
 

--- a/src/pages/stamps/PostageStampStandardCreation.tsx
+++ b/src/pages/stamps/PostageStampStandardCreation.tsx
@@ -13,6 +13,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as StampsContext } from '../../providers/Stamps'
 import { ROUTES } from '../../routes'
 import { secondsToTimeString } from '../../utils'
+import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '../../utils/bee-error'
 import { validateDepthInput } from '../../utils/stamp'
 
 interface Props {
@@ -50,7 +51,7 @@ export function PostageStampStandardCreation({ onFinished }: Props): ReactElemen
   const { classes } = useStyles()
   const { refresh } = useContext(StampsContext)
   const { beeApi } = useContext(SettingsContext)
-  const { chainState } = useContext(BeeContext)
+  const { chainState, walletBalance } = useContext(BeeContext)
   const [depthInput, setDepthInput] = useState<number>(Utils.getDepthForSize(Size.fromGigabytes(4)))
   const [amountInput, setAmountInput] = useState<bigint>(Utils.getAmountForDuration(Duration.fromDays(30), 26500, 5))
   const [labelInput, setLabelInput] = useState('')
@@ -110,6 +111,14 @@ export function PostageStampStandardCreation({ onFinished }: Props): ReactElemen
     let success = false
 
     try {
+      const fundsShortage = getStampFundsShortageMessage(Utils.getStampCost(depthInput, amountInput), walletBalance)
+
+      if (fundsShortage) {
+        enqueueSnackbar(fundsShortage, { variant: 'error' })
+
+        return
+      }
+
       setSubmitting(true)
 
       await beeApi.buyStorage(
@@ -125,7 +134,7 @@ export function PostageStampStandardCreation({ onFinished }: Props): ReactElemen
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e)
-      enqueueSnackbar(`Error: ${(e as Error).message}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to buy postage stamp: ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
     } finally {
       setSubmitting(false)
     }

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -9,7 +9,11 @@ import { BeeResponseError, BZZ, DAI, WalletBalance } from '@ethersphere/bee-js'
  */
 export function extractBeeApiErrorMessage(error: unknown): string {
   if (error instanceof BeeResponseError) {
-    const body = error.responseBody as { message?: unknown } | undefined
+    const body = error.responseBody as { message?: unknown } | string | undefined
+
+    if (typeof body === 'string' && body) {
+      return body
+    }
 
     if (body && typeof body === 'object' && typeof body.message === 'string' && body.message) {
       return body.message

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -39,14 +39,14 @@ export function getStampFundsShortageMessage(cost: BZZ, walletBalance: WalletBal
 
   if (cost.gt(walletBalance.bzzBalance)) {
     return (
-      `Insufficient xBZZ balance: this stamp costs ${cost.toSignificantDigits(4)} xBZZ, ` +
-      `but your node's wallet only has ${walletBalance.bzzBalance.toSignificantDigits(4)} xBZZ. ` +
+      `Not enough xBZZ: need ${cost.toSignificantDigits(4)}, ` +
+      `have ${walletBalance.bzzBalance.toSignificantDigits(4)}. ` +
       'Add funds under Account > Wallet.'
     )
   }
 
   if (DAI.fromDecimalString('0').eq(walletBalance.nativeTokenBalance)) {
-    return "Your node's wallet has no xDAI to pay for gas fees. Add funds under Account > Wallet."
+    return 'No xDAI to pay for gas fees. Add funds under Account > Wallet.'
   }
 
   return null

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -1,4 +1,5 @@
 import { BeeResponseError, BZZ, DAI, WalletBalance } from '@ethersphere/bee-js'
+import { ProviderContext } from 'notistack'
 
 /**
  * Extracts the most meaningful, human-readable reason from an error thrown by the Bee API.
@@ -50,4 +51,25 @@ export function getStampFundsShortageMessage(cost: BZZ, walletBalance: WalletBal
   }
 
   return null
+}
+
+/**
+ * Shows an error snackbar when the node's wallet cannot cover a stamp purchase.
+ *
+ * @returns true when the purchase should be aborted
+ */
+export function notifyStampFundsShortage(
+  cost: BZZ,
+  walletBalance: WalletBalance | null,
+  enqueueSnackbar: ProviderContext['enqueueSnackbar'],
+): boolean {
+  const fundsShortage = getStampFundsShortageMessage(cost, walletBalance)
+
+  if (fundsShortage) {
+    enqueueSnackbar(fundsShortage, { variant: 'error' })
+
+    return true
+  }
+
+  return false
 }

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -1,0 +1,49 @@
+import { BeeResponseError, BZZ, DAI, WalletBalance } from '@ethersphere/bee-js'
+
+/**
+ * Extracts the most meaningful, human-readable reason from an error thrown by the Bee API.
+ *
+ * Bee-js `BeeResponseError.message` only contains the generic HTTP layer message
+ * (e.g. "Request failed with status code 402"), while the actual reason reported by the
+ * Bee node (e.g. "out of funds") is in `responseBody`.
+ */
+export function extractBeeApiErrorMessage(error: unknown): string {
+  if (error instanceof BeeResponseError) {
+    const body = error.responseBody as { message?: unknown } | undefined
+
+    if (body && typeof body === 'object' && typeof body.message === 'string' && body.message) {
+      return body.message
+    }
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+/**
+ * Checks whether the node's wallet can cover a stamp purchase before sending the transaction.
+ *
+ * @returns an actionable error message, or null when the balance is sufficient or unknown
+ */
+export function getStampFundsShortageMessage(cost: BZZ, walletBalance: WalletBalance | null): string | null {
+  if (!walletBalance) {
+    return null
+  }
+
+  if (cost.gt(walletBalance.bzzBalance)) {
+    return (
+      `Insufficient xBZZ balance: this stamp costs ${cost.toSignificantDigits(4)} xBZZ, ` +
+      `but your node's wallet only has ${walletBalance.bzzBalance.toSignificantDigits(4)} xBZZ. ` +
+      'Add funds under Account > Wallet.'
+    )
+  }
+
+  if (DAI.fromDecimalString('0').eq(walletBalance.nativeTokenBalance)) {
+    return "Your node's wallet has no xDAI to pay for gas fees. Add funds under Account > Wallet."
+  }
+
+  return null
+}

--- a/tests/unit/bee-error.spec.ts
+++ b/tests/unit/bee-error.spec.ts
@@ -26,6 +26,19 @@ describe('extractBeeApiErrorMessage', () => {
     expect(extractBeeApiErrorMessage(error)).toBe('out of funds')
   })
 
+  it('should return a plain-text response body as-is', () => {
+    const error = new BeeResponseError(
+      'post',
+      '/stamps/1/17',
+      'Request failed with status code 402',
+      'out of funds',
+      402,
+      'Payment Required',
+    )
+
+    expect(extractBeeApiErrorMessage(error)).toBe('out of funds')
+  })
+
   it('should fall back to the error message when there is no response body', () => {
     const error = new BeeResponseError('post', '/stamps/1/17', 'Network Error', undefined, undefined, undefined)
 

--- a/tests/unit/bee-error.spec.ts
+++ b/tests/unit/bee-error.spec.ts
@@ -1,0 +1,70 @@
+import { BeeResponseError, BZZ, DAI, WalletBalance } from '@ethersphere/bee-js'
+
+import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '@/utils/bee-error'
+
+function makeWalletBalance(bzz: string, dai: string): WalletBalance {
+  return {
+    bzzBalance: BZZ.fromDecimalString(bzz),
+    nativeTokenBalance: DAI.fromDecimalString(dai),
+    chainID: 100,
+    chequebookContractAddress: '0x0',
+    walletAddress: '0x0',
+  }
+}
+
+describe('extractBeeApiErrorMessage', () => {
+  it('should return the Bee node message from the response body', () => {
+    const error = new BeeResponseError(
+      'post',
+      '/stamps/1/17',
+      'Request failed with status code 400',
+      { code: 400, message: 'out of funds' },
+      400,
+      'Bad Request',
+    )
+
+    expect(extractBeeApiErrorMessage(error)).toBe('out of funds')
+  })
+
+  it('should fall back to the error message when there is no response body', () => {
+    const error = new BeeResponseError('post', '/stamps/1/17', 'Network Error', undefined, undefined, undefined)
+
+    expect(extractBeeApiErrorMessage(error)).toBe('Network Error')
+  })
+
+  it('should handle plain errors', () => {
+    expect(extractBeeApiErrorMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('should handle non-error values', () => {
+    expect(extractBeeApiErrorMessage('boom')).toBe('boom')
+  })
+})
+
+describe('getStampFundsShortageMessage', () => {
+  it('should report insufficient xBZZ with concrete amounts', () => {
+    const cost = BZZ.fromDecimalString('0.6144')
+    const message = getStampFundsShortageMessage(cost, makeWalletBalance('0.05', '1'))
+
+    expect(message).toContain('Insufficient xBZZ balance')
+    expect(message).toContain('0.6144')
+    expect(message).toContain('0.05')
+  })
+
+  it('should report missing xDAI for gas fees', () => {
+    const cost = BZZ.fromDecimalString('0.1')
+    const message = getStampFundsShortageMessage(cost, makeWalletBalance('1', '0'))
+
+    expect(message).toContain('no xDAI')
+  })
+
+  it('should return null when the balance is sufficient', () => {
+    const cost = BZZ.fromDecimalString('0.1')
+
+    expect(getStampFundsShortageMessage(cost, makeWalletBalance('1', '1'))).toBeNull()
+  })
+
+  it('should return null when the balance is unknown', () => {
+    expect(getStampFundsShortageMessage(BZZ.fromDecimalString('1'), null)).toBeNull()
+  })
+})

--- a/tests/unit/bee-error.spec.ts
+++ b/tests/unit/bee-error.spec.ts
@@ -59,7 +59,7 @@ describe('getStampFundsShortageMessage', () => {
     const cost = BZZ.fromDecimalString('0.6144')
     const message = getStampFundsShortageMessage(cost, makeWalletBalance('0.05', '1'))
 
-    expect(message).toContain('Insufficient xBZZ balance')
+    expect(message).toContain('Not enough xBZZ')
     expect(message).toContain('0.6144')
     expect(message).toContain('0.05')
   })
@@ -68,7 +68,7 @@ describe('getStampFundsShortageMessage', () => {
     const cost = BZZ.fromDecimalString('0.1')
     const message = getStampFundsShortageMessage(cost, makeWalletBalance('1', '0'))
 
-    expect(message).toContain('no xDAI')
+    expect(message).toContain('No xDAI')
   })
 
   it('should return null when the balance is sufficient', () => {

--- a/tests/unit/bee-error.spec.ts
+++ b/tests/unit/bee-error.spec.ts
@@ -1,6 +1,6 @@
 import { BeeResponseError, BZZ, DAI, WalletBalance } from '@ethersphere/bee-js'
 
-import { extractBeeApiErrorMessage, getStampFundsShortageMessage } from '@/utils/bee-error'
+import { extractBeeApiErrorMessage, getStampFundsShortageMessage, notifyStampFundsShortage } from '@/utils/bee-error'
 
 function makeWalletBalance(bzz: string, dai: string): WalletBalance {
   return {
@@ -79,5 +79,27 @@ describe('getStampFundsShortageMessage', () => {
 
   it('should return null when the balance is unknown', () => {
     expect(getStampFundsShortageMessage(BZZ.fromDecimalString('1'), null)).toBeNull()
+  })
+})
+
+describe('notifyStampFundsShortage', () => {
+  it('should show an error snackbar and return true on shortage', () => {
+    const enqueueSnackbar = jest.fn()
+    const aborted = notifyStampFundsShortage(
+      BZZ.fromDecimalString('1'),
+      makeWalletBalance('0.05', '1'),
+      enqueueSnackbar,
+    )
+
+    expect(aborted).toBe(true)
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.stringContaining('Not enough xBZZ'), { variant: 'error' })
+  })
+
+  it('should not notify and return false when the balance is sufficient', () => {
+    const enqueueSnackbar = jest.fn()
+    const aborted = notifyStampFundsShortage(BZZ.fromDecimalString('0.1'), makeWalletBalance('1', '1'), enqueueSnackbar)
+
+    expect(aborted).toBe(false)
+    expect(enqueueSnackbar).not.toHaveBeenCalled()
   })
 })

--- a/utils/mock-bee-proxy.js
+++ b/utils/mock-bee-proxy.js
@@ -9,7 +9,9 @@
  *
  *   STATUS=400 MESSAGE='out of funds' pnpm mock:bee   # POST /stamps/* fails with that error
  *   POOR_WALLET=1 pnpm mock:bee                       # GET /wallet reports ~0 balances
- *   POOR_WALLET=1 BZZ=999999999999999999 DAI=0 pnpm mock:bee
+ *   POOR_WALLET=1 PLUR=999999999999999999 WEI=0 pnpm mock:bee
+ *
+ * PLUR is the xBZZ base unit (1 xBZZ = 1e16 PLUR), WEI the xDAI base unit (1 xDAI = 1e18 wei).
  *
  * Then point the dashboard's Bee API endpoint (Settings page) to http://localhost:11633.
  * Real node messages to simulate (bee pkg/api/postage.go): "out of funds", "invalid depth",
@@ -17,7 +19,7 @@
  */
 const http = require('http')
 
-const { STATUS, MESSAGE, POOR_WALLET, BZZ = '100', DAI = '0' } = process.env
+const { STATUS, MESSAGE, POOR_WALLET, PLUR = '100', WEI = '0' } = process.env
 const BEE_API = { host: 'localhost', port: 1633 }
 const PORT = 11633
 
@@ -29,13 +31,17 @@ http
     }
 
     if (STATUS && req.method === 'POST' && req.url.startsWith('/stamps/')) {
+      console.log(`[mock]  ${req.method} ${req.url} -> ${STATUS} "${MESSAGE}"`)
+
       return json(Number(STATUS), { code: Number(STATUS), message: MESSAGE })
     }
 
     if (POOR_WALLET && req.method === 'GET' && req.url === '/wallet') {
+      console.log(`[mock]  ${req.method} ${req.url} -> 200 poor wallet (PLUR=${PLUR}, WEI=${WEI})`)
+
       return json(200, {
-        bzzBalance: BZZ,
-        nativeTokenBalance: DAI,
+        bzzBalance: PLUR,
+        nativeTokenBalance: WEI,
         chainID: 100,
         chequebookContractAddress: '0x0',
         walletAddress: '0x0',
@@ -43,10 +49,14 @@ http
     }
 
     const forward = http.request({ ...BEE_API, path: req.url, method: req.method, headers: req.headers }, upstream => {
+      console.log(`[proxy] ${req.method} ${req.url} -> bee ${upstream.statusCode}`)
       res.writeHead(upstream.statusCode, upstream.headers)
       upstream.pipe(res)
     })
-    forward.on('error', () => json(502, { code: 502, message: 'mock proxy: bee node unreachable' }))
+    forward.on('error', () => {
+      console.log(`[proxy] ${req.method} ${req.url} -> bee unreachable`)
+      json(502, { code: 502, message: 'mock proxy: bee node unreachable' })
+    })
     req.pipe(forward)
   })
   .listen(PORT, () => {

--- a/utils/mock-bee-proxy.js
+++ b/utils/mock-bee-proxy.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable no-console */
+
+/**
+ * Dev helper to manually test postage stamp error handling in the dashboard.
+ *
+ * Proxies all requests to a real Bee node, optionally overriding selected endpoints:
+ *
+ *   STATUS=400 MESSAGE='out of funds' pnpm mock:bee   # POST /stamps/* fails with that error
+ *   POOR_WALLET=1 pnpm mock:bee                       # GET /wallet reports ~0 balances
+ *   POOR_WALLET=1 BZZ=999999999999999999 DAI=0 pnpm mock:bee
+ *
+ * Then point the dashboard's Bee API endpoint (Settings page) to http://localhost:11633.
+ * Real node messages to simulate (bee pkg/api/postage.go): "out of funds", "invalid depth",
+ * "insufficient amount for 24h minimum validity", "no chain backend", "cannot create batch".
+ */
+const http = require('http')
+
+const { STATUS, MESSAGE, POOR_WALLET, BZZ = '100', DAI = '0' } = process.env
+const BEE_API = { host: 'localhost', port: 1633 }
+const PORT = 11633
+
+http
+  .createServer((req, res) => {
+    const json = (code, body) => {
+      res.writeHead(code, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' })
+      res.end(JSON.stringify(body))
+    }
+
+    if (STATUS && req.method === 'POST' && req.url.startsWith('/stamps/')) {
+      return json(Number(STATUS), { code: Number(STATUS), message: MESSAGE })
+    }
+
+    if (POOR_WALLET && req.method === 'GET' && req.url === '/wallet') {
+      return json(200, {
+        bzzBalance: BZZ,
+        nativeTokenBalance: DAI,
+        chainID: 100,
+        chequebookContractAddress: '0x0',
+        walletAddress: '0x0',
+      })
+    }
+
+    const forward = http.request({ ...BEE_API, path: req.url, method: req.method, headers: req.headers }, upstream => {
+      res.writeHead(upstream.statusCode, upstream.headers)
+      upstream.pipe(res)
+    })
+    forward.on('error', () => json(502, { code: 502, message: 'mock proxy: bee node unreachable' }))
+    req.pipe(forward)
+  })
+  .listen(PORT, () => {
+    console.log(`Mock bee proxy on http://localhost:${PORT} -> http://${BEE_API.host}:${BEE_API.port}`, {
+      STATUS,
+      MESSAGE,
+      POOR_WALLET,
+    })
+  })


### PR DESCRIPTION
## UX: user-friendly errors when postage stamp purchase fails on insufficient funds

  Fixes [SPDV-1279](https://solar-punk.atlassian.net/browse/SPDV-1279) · Upstream issue: ethersphere/swarm-desktop#513

  ### Problem

  Buying a postage stamp without sufficient funds showed a generic red snackbar like
  `Error: Request failed with status code 402` — no hint that the wallet balance was
  the problem or what to do about it.

  ### Changes

  **Pre-flight balance check** — before sending the purchase request, both creation
  forms (Standard and Advanced) compare the stamp cost (`Utils.getStampCost`) against
  the node wallet's xBZZ balance and check for zero xDAI:

  - `Not enough xBZZ: need 0.6144, have 0.05. Add funds under Account > Wallet.`
  - `No xDAI to pay for gas fees. Add funds under Account > Wallet.`

  **Parse Bee API error responses** — when the node rejects a purchase, the snackbar
  now shows the node's actual reason from the response body (e.g. `out of funds`)
  instead of the generic HTTP-layer message. Handles JSON `{code, message}` bodies,
  plain-text bodies, and falls back to `Error.message`. No string pattern-matching —
  only structured fields are used (`new src/utils/bee-error.ts`).

  **Dev helper** — `utils/mock-bee-proxy.js` proxies a real Bee node and can simulate
  failure scenarios for manual testing:

  ```sh
  pnpm mock:bee:nofunds   # POST /stamps/* fails with 400 "out of funds"
  pnpm mock:bee:poor      # GET /wallet reports ~0 balances
  ```

  Point the dashboard's Bee API endpoint (Settings) to `http://localhost:11633`.

[SPDV-1279]: https://solar-punk.atlassian.net/browse/SPDV-1279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ