### PR TITLE
fix: apply secondary color to status check button

### DIFF
--- a/src/components/TroubleshootConnectionCard.tsx
+++ b/src/components/TroubleshootConnectionCard.tsx
@@ -21,6 +21,9 @@ const useStyles = makeStyles()(theme => ({
   icon: {
     height: '1rem',
   },
+  statusButton: {
+    color: theme.palette.secondary.main,
+  },
 }))
 
 export default function TroubleshootConnectionCard(): ReactElement {
@@ -49,6 +52,7 @@ export default function TroubleshootConnectionCard(): ReactElement {
       <Grid className={classes.content}>
         <Typography align="center">
           <Button
+            className={classes.statusButton}
             component={Link}
             variant="contained"
             startIcon={<Activity className={classes.icon} />}


### PR DESCRIPTION
Changes:
- On the fallback page (TroubleshootConnectionCard.tsx), the "Check node status" text was changed to a darker color to improve readability.