### PR TITLE
fix: format-raw-error-objects-in-snackbars-spdv-1323

### DIFF
--- a/src/components/StampExtensionModal.tsx
+++ b/src/components/StampExtensionModal.tsx
@@ -20,7 +20,6 @@ import React, { ReactElement, ReactNode, useContext, useEffect, useState } from 
 import { makeStyles } from 'tss-react/mui'
 
 import { CheckState, Context as BeeContext } from '../providers/Bee'
-import { extractBeeApiErrorMessage } from '../utils/bee-error'
 import { preciseTimeString } from '../utils'
 import { getHumanReadableFileSize } from '../utils/file'
 

--- a/src/components/StampExtensionModal.tsx
+++ b/src/components/StampExtensionModal.tsx
@@ -10,8 +10,8 @@ import { useSnackbar } from 'notistack'
 import React, { ReactElement, ReactNode, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
-import { extractBeeApiErrorMessage } from '../utils/bee-error'
 import { CheckState } from '../providers/Bee'
+import { extractBeeApiErrorMessage } from '../utils/bee-error'
 
 const useStyles = makeStyles()(theme => ({
   buttonSelected: {

--- a/src/components/StampExtensionModal.tsx
+++ b/src/components/StampExtensionModal.tsx
@@ -10,6 +10,7 @@ import { useSnackbar } from 'notistack'
 import React, { ReactElement, ReactNode, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
+import { extractBeeApiErrorMessage } from '../utils/bee-error'
 import { CheckState } from '../providers/Bee'
 
 const useStyles = makeStyles()(theme => ({
@@ -80,7 +81,9 @@ export default function StampExtensionModal({ type, icon, bee, stamp, status }: 
         await bee.topUpBatch(stamp.batchID, amount)
         enqueueSnackbar(`Successfully topped up stamp, your changes will appear soon`, { variant: 'success' })
       } catch (error) {
-        enqueueSnackbar(`Failed to topup stamp: ${error || 'Unknown reason'}`, { variant: 'error' })
+        // eslint-disable-next-line no-console
+        console.error(error)
+        enqueueSnackbar(`Failed to topup stamp: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
       }
 
       return
@@ -113,7 +116,9 @@ export default function StampExtensionModal({ type, icon, bee, stamp, status }: 
         await bee.diluteBatch(stamp.batchID, newDepth)
         enqueueSnackbar(`Successfully diluted stamp, your changes will appear soon`, { variant: 'success' })
       } catch (error) {
-        enqueueSnackbar(`Failed to dilute stamp: ${error || 'Unknown reason'}`, { variant: 'error' })
+        // eslint-disable-next-line no-console
+        console.error(error)
+        enqueueSnackbar(`Failed to dilute stamp: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
       }
 
       return

--- a/src/components/WithdrawDepositModal.tsx
+++ b/src/components/WithdrawDepositModal.tsx
@@ -11,6 +11,8 @@ import { useSnackbar } from 'notistack'
 import React, { ReactElement, ReactNode, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
+import { extractBeeApiErrorMessage } from '../utils/bee-error'
+
 const useStyles = makeStyles()(theme => ({
   link: {
     color: '#dd7700',
@@ -89,7 +91,7 @@ export default function WithdrawDepositModal({
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e)
-      enqueueSnackbar(`${errorMessage} Error: ${(e as Error).message}`, { variant: 'error' })
+      enqueueSnackbar(`${errorMessage} ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
     }
   }
 

--- a/src/pages/giftCode/index.tsx
+++ b/src/pages/giftCode/index.tsx
@@ -15,6 +15,7 @@ import { SwarmButton } from '../../components/SwarmButton'
 import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as TopUpContext } from '../../providers/TopUp'
 import { Context as BalanceProvider } from '../../providers/WalletBalance'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { createGiftWallet } from '../../utils/desktop'
 import { generateWallet } from '../../utils/identity'
 import { ResolvedWallet } from '../../utils/wallet'
@@ -66,7 +67,7 @@ export default function Index(): ReactElement | null {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Failed to fund gift wallet: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to fund gift wallet: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     } finally {
       setLoading(false)
     }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -6,6 +6,7 @@ import ExpandableList from '../../components/ExpandableList'
 import ExpandableListItemInput from '../../components/ExpandableListItemInput'
 import { Context as BeeContext } from '../../providers/Bee'
 import { Context as SettingsContext } from '../../providers/Settings'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { getDesktopConfiguration, restartBeeNode, setJsonRpcInDesktop } from '../../utils/desktop'
 
 export default function SettingsPage(): ReactElement {
@@ -48,7 +49,7 @@ export default function SettingsPage(): ReactElement {
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e)
-      enqueueSnackbar(`Failed to change RPC endpoint. ${e}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to change RPC endpoint. ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
     }
   }
 

--- a/src/pages/topUp/GiftCardFund.tsx
+++ b/src/pages/topUp/GiftCardFund.tsx
@@ -18,6 +18,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as BalanceProvider } from '../../providers/WalletBalance'
 import { ROUTES } from '../../routes'
 import { sleepMs } from '../../utils'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { restartBeeNode, upgradeToLightNode } from '../../utils/desktop'
 import { ResolvedWallet } from '../../utils/wallet'
 
@@ -57,7 +58,7 @@ export function GiftCardFund(): ReactElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Failed to upgrade: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to upgrade: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     }
   }
 
@@ -76,7 +77,7 @@ export function GiftCardFund(): ReactElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Failed to fund: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to fund: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     } finally {
       setLoading(false)
     }

--- a/src/pages/topUp/GiftCardTopUpIndex.tsx
+++ b/src/pages/topUp/GiftCardTopUpIndex.tsx
@@ -13,6 +13,7 @@ import { SwarmDivider } from '../../components/SwarmDivider'
 import { SwarmTextInput } from '../../components/SwarmTextInput'
 import { Context as SettingsContext } from '../../providers/Settings'
 import { ROUTES } from '../../routes'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { RPC } from '../../utils/rpc'
 
 export function GiftCardTopUpIndex(): ReactElement {
@@ -40,7 +41,7 @@ export function GiftCardTopUpIndex(): ReactElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Gift wallet could not be verified: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Gift wallet could not be verified: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     } finally {
       setLoading(false)
     }

--- a/src/pages/topUp/Swap.tsx
+++ b/src/pages/topUp/Swap.tsx
@@ -19,6 +19,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as BalanceProvider } from '../../providers/WalletBalance'
 import { ROUTES } from '../../routes'
 import { sleepMs } from '../../utils'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import {
   getBzzPriceAsDai,
   getDesktopConfiguration,
@@ -26,7 +27,6 @@ import {
   restartBeeNode,
   upgradeToLightNode,
 } from '../../utils/desktop'
-import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { isSwapError, SwapError, wrapWithSwapError } from '../../utils/errors'
 import { LocalStorageKeys } from '../../utils/localStorage'
 import { RPC } from '../../utils/rpc'
@@ -201,7 +201,9 @@ export function Swap({ header }: Props): ReactElement {
         }
       } else {
         // we have an unexpected error
-        enqueueSnackbar(`${GENERIC_SWAP_FAILED_ERROR_MESSAGE} ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
+        enqueueSnackbar(`${GENERIC_SWAP_FAILED_ERROR_MESSAGE} ${extractBeeApiErrorMessage(error)}`, {
+          variant: 'error',
+        })
         // eslint-disable-next-line no-console
         console.error(error)
       }

--- a/src/pages/topUp/Swap.tsx
+++ b/src/pages/topUp/Swap.tsx
@@ -26,6 +26,7 @@ import {
   restartBeeNode,
   upgradeToLightNode,
 } from '../../utils/desktop'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { isSwapError, SwapError, wrapWithSwapError } from '../../utils/errors'
 import { LocalStorageKeys } from '../../utils/localStorage'
 import { RPC } from '../../utils/rpc'
@@ -131,7 +132,7 @@ export function Swap({ header }: Props): ReactElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Failed to upgrade: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to upgrade: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     }
   }
 
@@ -200,7 +201,7 @@ export function Swap({ header }: Props): ReactElement {
         }
       } else {
         // we have an unexpected error
-        enqueueSnackbar(`${GENERIC_SWAP_FAILED_ERROR_MESSAGE} ${error}`, { variant: 'error' })
+        enqueueSnackbar(`${GENERIC_SWAP_FAILED_ERROR_MESSAGE} ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
         // eslint-disable-next-line no-console
         console.error(error)
       }

--- a/src/pages/topUp/index.tsx
+++ b/src/pages/topUp/index.tsx
@@ -19,6 +19,7 @@ import { CheckState, Context as BeeContext } from '../../providers/Bee'
 import { Context as SettingsContext } from '../../providers/Settings'
 import { Context as BalanceProvider } from '../../providers/WalletBalance'
 import { ROUTES } from '../../routes'
+import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { restartBeeNode, upgradeToLightNode } from '../../utils/desktop'
 
 const useStyles = makeStyles()(() => ({
@@ -61,7 +62,7 @@ export default function TopUp(): ReactElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error)
-      enqueueSnackbar(`Failed to upgrade: ${error}`, { variant: 'error' })
+      enqueueSnackbar(`Failed to upgrade: ${extractBeeApiErrorMessage(error)}`, { variant: 'error' })
     }
     setLoading(false)
   }

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -21,6 +21,11 @@ export function extractBeeApiErrorMessage(error: unknown): string {
     }
   }
 
+  // ethers v6 errors carry a shortMessage that is cleaner than .message
+  if (error instanceof Error && 'shortMessage' in error && typeof error.shortMessage === 'string' && error.shortMessage) {
+    return error.shortMessage
+  }
+
   if (error instanceof Error) {
     return error.message
   }

--- a/src/utils/bee-error.ts
+++ b/src/utils/bee-error.ts
@@ -22,7 +22,12 @@ export function extractBeeApiErrorMessage(error: unknown): string {
   }
 
   // ethers v6 errors carry a shortMessage that is cleaner than .message
-  if (error instanceof Error && 'shortMessage' in error && typeof error.shortMessage === 'string' && error.shortMessage) {
+  if (
+    error instanceof Error &&
+    'shortMessage' in error &&
+    typeof error.shortMessage === 'string' &&
+    error.shortMessage
+  ) {
     return error.shortMessage
   }
 


### PR DESCRIPTION
Changes:
- Extended the helper to support Ethers v6 errors to cleanly handle RPC/transaction failures.
- Wrapped raw error injections with `extractBeeApiErrorMessage()` and kept `console.error(error)` across all requested locations.