### PR TITLE
fix: resolve ENS names in file download/view

### DIFF
--- a/src/pages/files/AssetSummary.tsx
+++ b/src/pages/files/AssetSummary.tsx
@@ -1,10 +1,11 @@
 import { Reference } from '@ethersphere/bee-js'
 import { Box } from '@mui/material'
-import { ReactElement } from 'react'
+import { ReactElement, useContext } from 'react'
 
 import { DocumentationText } from '../../components/DocumentationText'
 import ExpandableListItemKey from '../../components/ExpandableListItemKey'
 import ExpandableListItemLink from '../../components/ExpandableListItemLink'
+import { Context as SettingsContext } from '../../providers/Settings'
 
 interface Props {
   isWebsite?: boolean
@@ -12,13 +13,18 @@ interface Props {
 }
 
 export function AssetSummary({ reference }: Props): ReactElement {
+  const { apiUrl } = useContext(SettingsContext)
   const isHash = reference ? Reference.isValid(reference) : false
 
   return (
     <>
       <Box mb={4}>
         {isHash && <ExpandableListItemKey label="Swarm hash" value={reference || ''} />}
-        {!isHash && <ExpandableListItemLink label="ENS" value={reference || ''} />}
+        {!isHash && (
+          // ENS names must be opened through the Bee node's /bzz endpoint (which resolves
+          // them); without an explicit link the icon would navigate to the bare ENS string.
+          <ExpandableListItemLink label="ENS" value={reference || ''} link={`${apiUrl}/bzz/${reference}/`} />
+        )}
       </Box>
       <DocumentationText>Files are accessed through your configured Bee API endpoint.</DocumentationText>
     </>

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,13 +1,28 @@
 import type { Bee, DownloadOptions } from '@ethersphere/bee-js'
 import { BeeRequestOptions, MantarayNode, NULL_ADDRESS } from '@ethersphere/bee-js'
 
+import { regexpEns } from '.'
+
 export async function loadManifest(
   beeApi: Bee,
   hash: string,
   options?: DownloadOptions,
   requestOptions?: BeeRequestOptions,
 ): Promise<MantarayNode> {
-  let manifest = await MantarayNode.unmarshal(beeApi, hash, options, requestOptions)
+  let manifest: MantarayNode
+
+  if (regexpEns.test(hash)) {
+    // MantarayNode.unmarshal() wraps its input in `new Reference()`, which throws on
+    // ENS names. Instead, let the Bee node resolve the name server-side via /bytes
+    // (this is where the node's configured ENS resolver is actually used) and unmarshal
+    // the returned root-node bytes. Child chunks are addressed by real hashes, so
+    // loadRecursively() works normally afterwards.
+    const data = (await beeApi.downloadData(hash, options, requestOptions)).toUint8Array()
+    manifest = MantarayNode.unmarshalFromData(data, NULL_ADDRESS)
+  } else {
+    manifest = await MantarayNode.unmarshal(beeApi, hash, options, requestOptions)
+  }
+
   await manifest.loadRecursively(beeApi, options, requestOptions)
 
   // If the manifest is a feed, resolve it and overwrite the manifest

--- a/tests/unit/manifest.spec.ts
+++ b/tests/unit/manifest.spec.ts
@@ -1,0 +1,66 @@
+import type { Bee } from '@ethersphere/bee-js'
+import { MantarayNode } from '@ethersphere/bee-js'
+
+import { loadManifest } from '../../src/utils/manifest'
+
+// A minimal stand-in for the MantarayNode returned by unmarshal / unmarshalFromData.
+// resolveFeed returns an Optional-like object whose ifPresentAsync never fires the
+// callback, i.e. "this manifest is not a feed".
+function makeFakeNode() {
+  return {
+    loadRecursively: jest.fn().mockResolvedValue(undefined),
+    resolveFeed: jest.fn().mockResolvedValue({
+      ifPresentAsync: jest.fn().mockResolvedValue(undefined),
+    }),
+  }
+}
+
+const VALID_HASH = 'a'.repeat(64)
+const ENS_NAME = 'litter-ally.eth'
+
+describe('loadManifest', () => {
+  let downloadData: jest.Mock
+  let beeApi: Bee
+  let unmarshalSpy: jest.SpyInstance
+  let unmarshalFromDataSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    downloadData = jest.fn().mockResolvedValue({ toUint8Array: () => new Uint8Array([1, 2, 3]) })
+    beeApi = { downloadData } as unknown as Bee
+
+    // Both unmarshal paths return our fake node so we can assert *which* one ran
+    // without exercising real chunk parsing.
+    unmarshalSpy = jest.spyOn(MantarayNode, 'unmarshal').mockResolvedValue(makeFakeNode() as never)
+    unmarshalFromDataSpy = jest.spyOn(MantarayNode, 'unmarshalFromData').mockReturnValue(makeFakeNode() as never)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('resolves an ENS name via the node (downloadData) instead of MantarayNode.unmarshal', async () => {
+    await expect(loadManifest(beeApi, ENS_NAME)).resolves.toBeDefined()
+
+    // The node resolves the ENS name server-side; the client never wraps it in a Reference.
+    expect(downloadData).toHaveBeenCalledWith(ENS_NAME, undefined, undefined)
+    expect(unmarshalFromDataSpy).toHaveBeenCalled()
+    expect(unmarshalSpy).not.toHaveBeenCalled()
+  })
+
+  it('routes ENS around MantarayNode.unmarshal, which rejects ENS via new Reference()', async () => {
+    // Reproduce real bee-js behaviour: unmarshal() wraps its input in new Reference(),
+    // which throws on a non-hex (ENS) reference. loadManifest must still resolve because
+    // it never calls unmarshal for ENS names.
+    unmarshalSpy.mockRejectedValue(new Error('not a valid hex string'))
+
+    await expect(loadManifest(beeApi, ENS_NAME)).resolves.toBeDefined()
+    expect(unmarshalSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps using MantarayNode.unmarshal for a plain swarm hash', async () => {
+    await expect(loadManifest(beeApi, VALID_HASH)).resolves.toBeDefined()
+
+    expect(unmarshalSpy).toHaveBeenCalledWith(beeApi, VALID_HASH, undefined, undefined)
+    expect(downloadData).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
**Problem**
Typing an ENS name (e.g. litter-ally.eth) into the Swarm Hash or ENS input and clicking Find failed to load the content, even with a correctly configured ENS resolver on the Bee node.

Two distinct bugs:
1. Manifest loading rejected ENS names. loadManifest calls MantarayNode.unmarshal, which (since bee-js 9.2.0) wraps its input in new Reference(). Reference only accepts a 64/128-char hex hash, so any .eth name threw immediately — the dashboard never asked the node to resolve it. This is a regression from the pre-revamp flow, where resolution was delegated to the node server-side.
2. The ENS "open" link was malformed. On the result page, AssetSummary rendered the ENS row via ExpandableListItemLink with no link prop, so the open icon did window.open('litter-ally.eth') — a bare relative URL with no Bee endpoint and no /bzz/.

**Fix**
- `src/utils/manifest.ts` — loadManifest now branches on ENS (using the same regexpEns the input validation uses). For ENS names it downloads the root node via beeApi.downloadData() (the Bee node resolves the name server-side through /bytes, using the configured resolver) and MantarayNode.unmarshalFromData()s the result. Hex hashes keep the original MantarayNode.unmarshal path. Everything downstream (loadRecursively, feed resolution) is unchanged. This fixes both Download and Share, which share this function.
- `src/pages/files/AssetSummary.tsx` — the ENS row now passes an explicit link={${apiUrl}/bzz/${reference}/}, matching the app's existing open-URL pattern, so the icon opens the resolved content through the node.

**Testing**
- New unit tests (tests/unit/manifest.spec.ts): ENS routes via downloadData (not unmarshal); a regression guard proving loadManifest still resolves even when unmarshal is rigged to reject like real bee-js does on ENS; hex hashes keep using unmarshal.
- tsc, lint, and full suite (69/69) green.
- Manually verified against a Bee node with a configured resolver: litter-ally.eth → Find renders the manifest, and the ENS row's open icon navigates to …/bzz/litter-ally.eth/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)