### PR TITLE
fix: added a component prop to Typography in ExpandableListItemNote

### DIFF
--- a/src/components/ExpandableListItemNote.tsx
+++ b/src/components/ExpandableListItemNote.tsx
@@ -22,7 +22,7 @@ export default function ExpandableListItemNote({ children }: Props): ReactElemen
 
   return (
     <ListItemButton className={classes.header}>
-      <Typography variant="body1" className={classes.typography}>
+      <Typography variant="body1" component="div" className={classes.typography}>
         {children}
       </Typography>
     </ListItemButton>


### PR DESCRIPTION
https://github.com/ethersphere/bee-dashboard/issues/567
*Found only one remaining file that needed the fix. As I see, most of the files are fixed.

Changes:
- Added `component="div"` to Typography in ExpandableListItemNote.tsx to prevent block children from being nested inside a <p> tag.