### PR TITLE
fix: guard chequebook fields against partial fetch crash

### DIFF
--- a/src/pages/account/chequebook/AccountChequebook.tsx
+++ b/src/pages/account/chequebook/AccountChequebook.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material'
 import { ReactElement, useContext } from 'react'
 
+import ErrorBoundary from '../../../components/ErrorBoundary'
 import ExpandableList from '../../../components/ExpandableList'
 import ExpandableListItem from '../../../components/ExpandableListItem'
 import ExpandableListItemActions from '../../../components/ExpandableListItemActions'
@@ -27,48 +28,50 @@ export function AccountChequebook(): ReactElement {
   const showChequebook = chequebookBalance?.totalBalance !== undefined
 
   return (
-    <>
-      <Header />
-      <AccountNavigation active="CHEQUEBOOK" />
-      <div>
-        {showChequebook && (
-          <ExpandableList label="Chequebook" defaultOpen>
-            <ExpandableListItem
-              label="Total Balance"
-              value={`${chequebookBalance?.totalBalance.toSignificantDigits(4)} xBZZ`}
-            />
-            <ExpandableListItem
-              label="Available Uncommitted Balance"
-              value={`${chequebookBalance?.availableBalance.toSignificantDigits(4)} xBZZ`}
-            />
-            <ExpandableListItem
-              label="Total Cheques Amount Sent"
-              value={`${settlements?.totalSent.toSignificantDigits(4)} xBZZ`}
-            />
-            <Box mb={2}>
+    <ErrorBoundary>
+      <>
+        <Header />
+        <AccountNavigation active="CHEQUEBOOK" />
+        <div>
+          {showChequebook && (
+            <ExpandableList label="Chequebook" defaultOpen>
               <ExpandableListItem
-                label="Total Cheques Amount Received"
-                value={`${settlements?.totalReceived.toSignificantDigits(4)} xBZZ`}
+                label="Total Balance"
+                value={`${chequebookBalance?.totalBalance?.toSignificantDigits(4) ?? '–'} xBZZ`}
               />
-            </Box>
-            <ExpandableListItemActions>
-              <WithdrawModal />
-              <DepositModal />
-            </ExpandableListItemActions>
+              <ExpandableListItem
+                label="Available Uncommitted Balance"
+                value={`${chequebookBalance?.availableBalance?.toSignificantDigits(4) ?? '–'} xBZZ`}
+              />
+              <ExpandableListItem
+                label="Total Cheques Amount Sent"
+                value={`${settlements?.totalSent?.toSignificantDigits(4) ?? '–'} xBZZ`}
+              />
+              <Box mb={2}>
+                <ExpandableListItem
+                  label="Total Cheques Amount Received"
+                  value={`${settlements?.totalReceived?.toSignificantDigits(4) ?? '–'} xBZZ`}
+                />
+              </Box>
+              <ExpandableListItemActions>
+                <WithdrawModal />
+                <DepositModal />
+              </ExpandableListItemActions>
+            </ExpandableList>
+          )}
+          <ExpandableList label="Blockchain" defaultOpen>
+            <ExpandableListItemKey
+              label="Ethereum address"
+              value={nodeAddresses?.ethereum ? nodeAddresses.ethereum.toChecksum() : ''}
+            />
+            <ExpandableListItemKey
+              label="Chequebook contract address"
+              value={chequebookAddress?.chequebookAddress.toString() || ''}
+            />
           </ExpandableList>
-        )}
-        <ExpandableList label="Blockchain" defaultOpen>
-          <ExpandableListItemKey
-            label="Ethereum address"
-            value={nodeAddresses?.ethereum ? nodeAddresses.ethereum.toChecksum() : ''}
-          />
-          <ExpandableListItemKey
-            label="Chequebook contract address"
-            value={chequebookAddress?.chequebookAddress.toString() || ''}
-          />
-        </ExpandableList>
-        <PeerBalances accounting={accounting} isLoadingUncashed={isLoadingUncashed} totalUncashed={totalUncashed} />
-      </div>
-    </>
+          <PeerBalances accounting={accounting} isLoadingUncashed={isLoadingUncashed} totalUncashed={totalUncashed} />
+        </div>
+      </>
+    </ErrorBoundary>
   )
 }

--- a/src/pages/account/chequebook/AccountChequebook.tsx
+++ b/src/pages/account/chequebook/AccountChequebook.tsx
@@ -37,20 +37,20 @@ export function AccountChequebook(): ReactElement {
             <ExpandableList label="Chequebook" defaultOpen>
               <ExpandableListItem
                 label="Total Balance"
-                value={`${chequebookBalance?.totalBalance?.toSignificantDigits(4) ?? '–'} xBZZ`}
+                value={`${chequebookBalance?.totalBalance?.toSignificantDigits(4) ?? '—'} xBZZ`}
               />
               <ExpandableListItem
                 label="Available Uncommitted Balance"
-                value={`${chequebookBalance?.availableBalance?.toSignificantDigits(4) ?? '–'} xBZZ`}
+                value={`${chequebookBalance?.availableBalance?.toSignificantDigits(4) ?? '—'} xBZZ`}
               />
               <ExpandableListItem
                 label="Total Cheques Amount Sent"
-                value={`${settlements?.totalSent?.toSignificantDigits(4) ?? '–'} xBZZ`}
+                value={`${settlements?.totalSent?.toSignificantDigits(4) ?? '—'} xBZZ`}
               />
               <Box mb={2}>
                 <ExpandableListItem
                   label="Total Cheques Amount Received"
-                  value={`${settlements?.totalReceived?.toSignificantDigits(4) ?? '–'} xBZZ`}
+                  value={`${settlements?.totalReceived?.toSignificantDigits(4) ?? '—'} xBZZ`}
                 />
               </Box>
               <ExpandableListItemActions>


### PR DESCRIPTION
Changes:
- Extend optional chaining to the .toSignificantDigits() call on all four balance/settlement fields, so a null value from a failed refresh renders a dash instead of throwing "undefined".
- Wrap AccountChequebook in a page-level ErrorBoundary as a safety net for any future render errors on this page.