### PR TITLE
fix: resolve desktop config key migration in swap flow

### DIFF
--- a/src/pages/topUp/Swap.tsx
+++ b/src/pages/topUp/Swap.tsx
@@ -23,6 +23,7 @@ import {
   getBzzPriceAsDai,
   getDesktopConfiguration,
   performSwap,
+  resolveBlockchainRpcEndpoint,
   restartBeeNode,
   upgradeToLightNode,
 } from '../../utils/desktop'
@@ -162,12 +163,14 @@ export function Swap({ header }: Props): ReactElement {
       )
     }
 
-    if (!desktopConfiguration['blockchain-rpc-endpoint']) {
+    const blockchainRpcEndpoint = resolveBlockchainRpcEndpoint(desktopConfiguration)
+
+    if (!blockchainRpcEndpoint) {
       throw new SwapError('Blockchain RPC endpoint is not configured in Swarm Desktop')
     }
     await wrapWithSwapError(
-      RPC.getNetworkChainId(desktopConfiguration['blockchain-rpc-endpoint']),
-      `Blockchain RPC endpoint not reachable at ${desktopConfiguration['blockchain-rpc-endpoint']}`,
+      RPC.getNetworkChainId(blockchainRpcEndpoint),
+      `Blockchain RPC endpoint not reachable at ${blockchainRpcEndpoint}`,
     )
     await wrapWithSwapError(sendSwapRequest(daiToSwap), GENERIC_SWAP_FAILED_ERROR_MESSAGE)
   }

--- a/src/providers/Settings.tsx
+++ b/src/providers/Settings.tsx
@@ -5,6 +5,7 @@ import { createContext, ReactElement, ReactNode, useCallback, useEffect, useMemo
 import { DEFAULT_BEE_API_HOST, DEFAULT_RPC_URL } from '../constants'
 import { useGetBeeConfig } from '../hooks/apiHooks'
 import { newGnosisProvider } from '../utils/chain'
+import { resolveBlockchainRpcEndpoint } from '../utils/desktop'
 import { LocalStorageKeys } from '../utils/localStorage'
 
 interface ContextInterface {
@@ -104,9 +105,10 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
   }, [config, apiUrl])
 
   useEffect(() => {
-    if (!isDesktop || !config?.['blockchain-rpc-endpoint']) return
+    const daemonRpcUrl = config ? resolveBlockchainRpcEndpoint(config) : undefined
 
-    const daemonRpcUrl = config['blockchain-rpc-endpoint']
+    if (!isDesktop || !daemonRpcUrl) return
+
     localStorage.setItem(LocalStorageKeys.providerUrl, daemonRpcUrl)
     setRpcProviderUrl(daemonRpcUrl)
     setRpcProvider(newGnosisProvider(daemonRpcUrl))

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -18,6 +18,11 @@ export interface BeeConfig {
   'data-dir': string
   'config-file-path'?: string
   'blockchain-rpc-endpoint'?: string
+  'swap-endpoint'?: string // deprecated: returned by pre-migration Swarm Desktop
+}
+
+export function resolveBlockchainRpcEndpoint(config: BeeConfig): string | undefined {
+  return config['blockchain-rpc-endpoint'] ?? config['swap-endpoint']
 }
 
 export async function getBzzPriceAsDai(desktopUrl: string): Promise<DAI> {


### PR DESCRIPTION
Changes:
- Add a central helper function resolveBlockchainRpcEndpoint in desktop.ts to handle both the current blockchain-rpc-endpoint and the deprecated swap-endpoint keys, using nullish coalescing so migrated and pre-migration Desktop versions are both recognized.
- Updated Settings.tsx to use the helper when reading the daemon RPC URL from the Desktop config, ensuring rpcProviderUrl is correctly populated regardless of which key the Desktop API returns. This also fixes the upgradeToLightNode input: it receives rpcProviderUrl from context, so an incorrect/empty value here would have silently misconfigured the light node upgrade.
- Updated Swap.tsx (performSwapWithChecks) to use the helper for the pre-swap endpoint check, eliminating the misleading "Blockchain RPC endpoint is not configured" error for users whose nodes are correctly configured but running a pre-migration Desktop version.
- upgradeToLightNode already wrote blockchain-rpc-endpoint correctly and required no changes.