### PR TITLE
feat: make ENS resolver URL editable from UI

### DIFF
--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -61,9 +61,9 @@ export default function SettingsPage(): ReactElement {
 
   async function handleSetEnsResolverUrl(value: string) {
     try {
+      await setEnsResolverInDesktop(desktopUrl, value)
       setEnsResolver(value)
 
-      await setEnsResolverInDesktop(desktopUrl, value)
       const snackKey = enqueueSnackbar('ENS resolver successfully changed, restarting Bee node...', {
         variant: 'success',
       })

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -7,7 +7,12 @@ import ExpandableListItemInput from '../../components/ExpandableListItemInput'
 import { Context as BeeContext } from '../../providers/Bee'
 import { Context as SettingsContext } from '../../providers/Settings'
 import { extractBeeApiErrorMessage } from '../../utils/bee-error'
-import { getDesktopConfiguration, restartBeeNode, setJsonRpcInDesktop } from '../../utils/desktop'
+import {
+  getDesktopConfiguration,
+  restartBeeNode,
+  setEnsResolverInDesktop,
+  setJsonRpcInDesktop,
+} from '../../utils/desktop'
 
 export default function SettingsPage(): ReactElement {
   const {
@@ -23,6 +28,7 @@ export default function SettingsPage(): ReactElement {
     isDesktop,
     desktopUrl,
     setAndPersistJsonRpcProvider,
+    setEnsResolver,
   } = useContext(SettingsContext)
   const { refresh } = useContext(BeeContext)
   const { enqueueSnackbar, closeSnackbar } = useSnackbar()
@@ -50,6 +56,26 @@ export default function SettingsPage(): ReactElement {
       // eslint-disable-next-line no-console
       console.error(e)
       enqueueSnackbar(`Failed to change RPC endpoint. ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
+    }
+  }
+
+  async function handleSetEnsResolverUrl(value: string) {
+    try {
+      setEnsResolver(value)
+
+      await setEnsResolverInDesktop(desktopUrl, value)
+      const snackKey = enqueueSnackbar('ENS resolver successfully changed, restarting Bee node...', {
+        variant: 'success',
+      })
+      await restartBeeNode(desktopUrl)
+      closeSnackbar(snackKey)
+      enqueueSnackbar('Bee node restarted', { variant: 'success' })
+
+      await refresh()
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+      enqueueSnackbar(`Failed to change ENS resolver. ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
     }
   }
 
@@ -83,7 +109,13 @@ export default function SettingsPage(): ReactElement {
           <ExpandableListItemInput label="CORS" value={cors ?? '-'} locked />
           <ExpandableListItemInput label="Data DIR" value={dataDir ?? '-'} locked />
           <ExpandableListItemInput label="Config file" value={configFile ?? '-'} locked />
-          <ExpandableListItemInput label="ENS resolver URL" value={ensResolver ?? '-'} locked />
+          <ExpandableListItemInput
+            label="ENS resolver URL"
+            value={ensResolver ?? '-'}
+            helperText="Changing the value will restart your bee node."
+            confirmLabel="Save and restart"
+            onConfirm={handleSetEnsResolverUrl}
+          />
         </ExpandableList>
       )}
     </>

--- a/src/providers/Settings.tsx
+++ b/src/providers/Settings.tsx
@@ -23,6 +23,7 @@ interface ContextInterface {
   ensResolver: string | null
   setApiUrl: (url: string) => void
   setAndPersistJsonRpcProvider: (url: string) => void
+  setEnsResolver: (url: string) => void
   isLoading: boolean
   error: Error | null
 }
@@ -42,6 +43,7 @@ const initialValues: ContextInterface = {
   dataDir: null,
   configFile: null,
   ensResolver: null,
+  setEnsResolver: () => {},
   isLoading: true,
   error: null,
 }
@@ -75,6 +77,7 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
   const [desktopApiKey, setDesktopApiKey] = useState<string>(initialValues.desktopApiKey)
   const [rpcProviderUrl, setRpcProviderUrl] = useState(propsProviderUrl)
   const [rpcProvider, setRpcProvider] = useState(newGnosisProvider(propsProviderUrl))
+  const [ensResolver, setEnsResolverState] = useState<string | null>(initialValues.ensResolver)
 
   const { config, isLoading, error } = useGetBeeConfig(desktopUrl)
 
@@ -112,6 +115,12 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
     setRpcProvider(newGnosisProvider(daemonRpcUrl))
   }, [isDesktop, config])
 
+  useEffect(() => {
+    if (!isDesktop || !config?.['resolver-options']) return
+
+    setEnsResolverState(config['resolver-options'])
+  }, [isDesktop, config])
+
   const updateApiUrl = useCallback((url: string) => {
     const userProvidedUrl = makeHttpUrl(url)
 
@@ -130,6 +139,10 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
     setRpcProvider(newGnosisProvider(providerUrl))
   }, [])
 
+  const setEnsResolver = useCallback((url: string) => {
+    setEnsResolverState(url)
+  }, [])
+
   const contextValue = useMemo(
     () => ({
       apiUrl,
@@ -145,8 +158,9 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
       cors: config?.['cors-allowed-origins'] ?? null,
       dataDir: config?.['data-dir'] ?? null,
       configFile: config?.['config-file-path'] ?? null,
-      ensResolver: config?.['resolver-options'] ?? null,
+      ensResolver,
       setAndPersistJsonRpcProvider,
+      setEnsResolver,
       isLoading,
       error,
     }),
@@ -162,7 +176,9 @@ export function Provider({ children, ...propsSettings }: Props): ReactElement {
       rpcProvider,
       rpcProviderUrl,
       config,
+      ensResolver,
       setAndPersistJsonRpcProvider,
+      setEnsResolver,
       isLoading,
       error,
     ],

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -39,6 +39,12 @@ export async function setJsonRpcInDesktop(desktopUrl: string, value: string): Pr
   })
 }
 
+export async function setEnsResolverInDesktop(desktopUrl: string, value: string): Promise<void> {
+  await updateDesktopConfiguration(desktopUrl, {
+    'resolver-options': value,
+  })
+}
+
 export function getDesktopConfiguration(desktopUrl: string): Promise<BeeConfig> {
   return getJson(`${desktopUrl}/config`)
 }


### PR DESCRIPTION
This PR addresses the second part of SPDV-1342. While the first part of the ticket focused on the bugfix (in swarm-desktop), this second part functions more as a feature within the bee-dashboard.
It exposes the ENS resolver URL (resolver-options) as a configurable setting in the UI, mirroring the existing behavior of the Blockchain RPC URL.

Changes:
- Created setEnsResolverInDesktop to safely post the new resolver-options value to the desktop configuration endpoint.
- Created a dedicated ensResolver React state and a corresponding setEnsResolver modifier function.
- Added a new input field for the ENS resolver URL under the Settings section, utilizing optimistic UI updates and triggering a node restart upon saving.