### PR TITLE
docs: document mock Bee proxy dev helper in README.md (SPDV-1375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ pnpm start
 pnpm run desktop # This will inject the API key to the Dashboard
 ```
 
+#### Mock Bee proxy
+
+To manually test error handling without breaking a real node, `utils/mock-bee-proxy.js` proxies all requests to a local
+Bee node (`http://localhost:1633`) and can override selected endpoints with failure responses:
+
+- `pnpm mock:bee` — base script; pass-through by default, configurable via env variables
+- `pnpm mock:bee:nofunds` — preset: `POST /stamps/*` fails with `400 "out of funds"`
+- `pnpm mock:bee:poor` — preset: `GET /wallet` reports near-zero xBZZ/xDAI balances
+
+The proxy listens on `http://localhost:11633` — point the dashboard's Bee API endpoint (Settings page) there.
+For cases not covered by the presets, set the env variables (`STATUS`, `MESSAGE`, `POOR_WALLET`, `PLUR`, `WEI`) directly:
+
+```sh
+STATUS=507 MESSAGE='batch too large' pnpm mock:bee
+```
+
 ## File Manager
 
 The File Manager module provides intuitive decentralized file storage and management.


### PR DESCRIPTION
Documents the existing mock Bee proxy dev helper (`utils/mock-bee-proxy.js`) in the README, which previously had no mention of it. The new "Mock Bee proxy" section under the development setup explains:

  - What the proxy is for: manually testing the dashboard's error handling by overriding selected Bee endpoints with failure responses, while passing
  everything else through to a real local node (`http://localhost:1633`)
  - The available npm scripts: `pnpm mock:bee` (configurable pass-through), `pnpm mock:bee:nofunds` (stamp purchase fails with `400 "out of funds"`), and
  `pnpm mock:bee:poor` (near-zero wallet balances)
  - How to use it: point the dashboard's Bee API endpoint at `http://localhost:11633`, and use the `STATUS`, `MESSAGE`, `POOR_WALLET`, `PLUR`, `WEI` env
  variables for cases the presets don't cover, with an example

  Docs-only change — no code affected.