### PR TITLE
fix: spdv-1388

### DIFF
--- a/src/components/WithdrawDepositModal.tsx
+++ b/src/components/WithdrawDepositModal.tsx
@@ -8,7 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle'
 import FormHelperText from '@mui/material/FormHelperText'
 import Input from '@mui/material/Input'
 import { useSnackbar } from 'notistack'
-import React, { ReactElement, ReactNode, useState } from 'react'
+import React, { ReactElement, ReactNode, useRef, useState } from 'react'
 import { makeStyles } from 'tss-react/mui'
 
 import { extractBeeApiErrorMessage } from '../utils/bee-error'
@@ -67,6 +67,8 @@ export default function WithdrawDepositModal({
   const { classes } = useStyles()
 
   const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const loadingRef = useRef(false)
   const [amount, setAmount] = useState('')
   const [amountToken, setAmountToken] = useState<BZZ | null>(null)
   const [amountError, setAmountError] = useState<Error | null>(null)
@@ -82,7 +84,10 @@ export default function WithdrawDepositModal({
   }
 
   const handleAction = async () => {
-    if (amountToken === null) return
+    if (amountToken === null || loadingRef.current) return
+
+    loadingRef.current = true
+    setLoading(true)
 
     try {
       const transactionHash = await action(amountToken)
@@ -92,6 +97,9 @@ export default function WithdrawDepositModal({
       // eslint-disable-next-line no-console
       console.error(e)
       enqueueSnackbar(`${errorMessage} ${extractBeeApiErrorMessage(e)}`, { variant: 'error' })
+    } finally {
+      loadingRef.current = false
+      setLoading(false)
     }
   }
 
@@ -140,7 +148,7 @@ export default function WithdrawDepositModal({
           <Button onClick={handleClose} color="primary">
             Cancel
           </Button>
-          <Button onClick={handleAction} color="primary">
+          <Button onClick={handleAction} color="primary" disabled={loading}>
             {label}
           </Button>
         </DialogActions>


### PR DESCRIPTION
https://solar-punk.atlassian.net/browse/SPDV-1388

Changes:
The confirmation button in the Chequebook Deposit and Withdraw modals is now disabled while a transaction is in progress, preventing duplicate transactions from rapid clicks.