### PR TITLE
ci: add PR title conventional-commit check

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -9,6 +9,18 @@ on:
       - '**'
 
 jobs:
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: read
+
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   check:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Why

Squash merges use the **PR title** as the resulting commit subject on `master`. The existing commitlint action only validates the commits *inside* a PR, so a non-conventional PR title (e.g. `Feat: FileManager (#98)`, commit 5bfe2a0) lands in history unchecked.

## What

Adds a `pr-title` job to `check.yaml` using [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)@v6, which validates the PR title against the Conventional Commits format on every `opened`/`edited`/`synchronize` event.

## Follow-up (needs an admin)

- Add `pr-title` and `check (24.x)` as **required status checks** on `master` — without branch protection both remain advisory.
- Consider setting *Settings → General → Pull Requests → Default commit message: Pull request title* so squash merges actually use the validated title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)