### PR TITLE
fix: fall back to stewardship check when direct uploads create no tag

### DIFF
--- a/src/pages/files/AssetSyncing.tsx
+++ b/src/pages/files/AssetSyncing.tsx
@@ -16,6 +16,7 @@ export function AssetSyncing({ reference }: Props): ReactElement {
   const { beeApi } = useContext(SettingsContext)
 
   const syncTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+  const retrieveCheckRef = useRef<boolean>(false)
   const [isRetrieveChecking, setIsRetrieveChecking] = useState<boolean>(false)
   const [syncProgress, setSyncProgress] = useState<number>(0)
 
@@ -38,6 +39,19 @@ export function AssetSyncing({ reference }: Props): ReactElement {
     if (tag && tag.split > 0) {
       const progress = ((tag.seen + tag.synced) / tag.split) * 100
       setSyncProgress(progress)
+    } else if (!tag && !retrieveCheckRef.current) {
+      // Direct (non-deferred) uploads do not create a tag on the Bee node,
+      // so verify network availability with the stewardship endpoint instead
+      retrieveCheckRef.current = true
+      try {
+        if (await beeApi.isReferenceRetrievable(reference)) {
+          setSyncProgress(100)
+        }
+      } catch {
+        // Transient error, the next interval tick will retry
+      } finally {
+        retrieveCheckRef.current = false
+      }
     }
   }, [beeApi, reference])
 


### PR DESCRIPTION
Since uploads switched to deferred: false (SPDV-1337), the Bee node no longer creates a tag for uploads (tags are only created for deferred or pinned uploads), so the tag-based sync progress bar on the post-upload page stayed stuck at 0%. When no tag matches the uploaded reference, verify network availability via the stewardship endpoint and set the progress to 100%.

Fixes SPDV-1413