### PR TITLE
fix: validate ENS resolver URL before saving

### DIFF
--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -9,6 +9,7 @@ import { Context as SettingsContext } from '../../providers/Settings'
 import { extractBeeApiErrorMessage } from '../../utils/bee-error'
 import { newGnosisProviderForValidation } from '../../utils/chain'
 import {
+  extractEnsResolverUrl,
   getDesktopConfiguration,
   restartBeeNode,
   setEnsResolverInDesktop,
@@ -71,11 +72,31 @@ export default function SettingsPage(): ReactElement {
   }
 
   async function handleSetEnsResolverUrl(value: string) {
+    const resolverUrl = extractEnsResolverUrl(value)
+
+    if (!resolverUrl) {
+      enqueueSnackbar('Failed to change ENS resolver. Invalid URL format.', { variant: 'error' })
+
+      return
+    }
+
+    try {
+      await newGnosisProviderForValidation(resolverUrl).getNetwork()
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e)
+      enqueueSnackbar(`Failed to connect to ENS resolver endpoint. ${extractBeeApiErrorMessage(e)}`, {
+        variant: 'error',
+      })
+
+      return
+    }
+
     try {
       await setEnsResolverInDesktop(desktopUrl, value)
       setEnsResolver(value)
 
-      const snackKey = enqueueSnackbar('ENS resolver successfully changed, restarting Bee node...', {
+      const snackKey = enqueueSnackbar('ENS resolver saved, restarting Bee node...', {
         variant: 'success',
       })
       await restartBeeNode(desktopUrl)

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -50,6 +50,18 @@ export async function setEnsResolverInDesktop(desktopUrl: string, value: string)
   })
 }
 
+const ENS_RESOLVER_URL = /^(?:[^:/@]+:)?(?:[^@]+@)?(https?:\/\/.+)$/i
+
+export function extractEnsResolverUrl(value: string): string | null {
+  const urlPart = ENS_RESOLVER_URL.exec(value.trim())?.[1]
+
+  try {
+    return urlPart && new URL(urlPart).hostname ? urlPart : null
+  } catch {
+    return null
+  }
+}
+
 export function getDesktopConfiguration(desktopUrl: string): Promise<BeeConfig> {
   return getJson(`${desktopUrl}/config`)
 }

--- a/src/utils/desktop.ts
+++ b/src/utils/desktop.ts
@@ -50,7 +50,7 @@ export async function setEnsResolverInDesktop(desktopUrl: string, value: string)
   })
 }
 
-const ENS_RESOLVER_URL = /^(?:[^:/@]+:)?(?:[^@]+@)?(https?:\/\/.+)$/i
+const ENS_RESOLVER_URL = /^(?:[a-z0-9-]+:)?(?:0x[0-9a-fA-F]{40}@)?(https?:\/\/.+)$/i
 
 export function extractEnsResolverUrl(value: string): string | null {
   const urlPart = ENS_RESOLVER_URL.exec(value.trim())?.[1]

--- a/tests/unit/desktop.spec.ts
+++ b/tests/unit/desktop.spec.ts
@@ -1,0 +1,21 @@
+import { extractEnsResolverUrl } from '@/utils/desktop'
+
+describe('extractEnsResolverUrl', () => {
+  test('extracts a bare url', () => {
+    expect(extractEnsResolverUrl('https://rpc.example.com')).toBe('https://rpc.example.com')
+  })
+
+  test('extracts a url prefixed with tld and contract address', () => {
+    expect(extractEnsResolverUrl('eth:0x0000000000000000000000000000000000000000@https://rpc.example.com')).toBe(
+      'https://rpc.example.com',
+    )
+  })
+
+  test('returns null for an invalid contract address masquerading as one', () => {
+    expect(extractEnsResolverUrl('foo:bar@https://rpc.example.com')).toBeNull()
+  })
+
+  test('returns null for a non-url value', () => {
+    expect(extractEnsResolverUrl('not a url')).toBeNull()
+  })
+})


### PR DESCRIPTION
This PR is related to **SPDV-1342**

**Changes:**
- Validates the ENS resolver URL before saving: checks the format is valid and showing an error snackbar if check fails. Previously invalid input could be saved without any validation.