### PR TITLE
fix: feed-export

### DIFF
--- a/src/pages/feeds/ExportFeedDialog.tsx
+++ b/src/pages/feeds/ExportFeedDialog.tsx
@@ -11,7 +11,8 @@ import ExpandableListItemActions from '../../components/ExpandableListItemAction
 import { SwarmButton } from '../../components/SwarmButton'
 import { SwarmDialog } from '../../components/SwarmDialog'
 import { TitleWithClose } from '../../components/TitleWithClose'
-import { Identity, IdentityType } from '../../providers/Feeds'
+import { Identity } from '../../providers/Feeds'
+import { exportIdentity } from '../../utils/identity'
 
 interface Props {
   identity: Identity
@@ -29,23 +30,19 @@ export function ExportFeedDialog({ identity, onClose }: Props): ReactElement {
 
   const { classes } = useStyles()
 
+  const exportData = exportIdentity(identity)
+
   function onDownload() {
     saveAs(
-      new Blob([identity.identity], {
+      new Blob([exportData], {
         type: 'application/json',
       }),
       identity.name + '.json',
     )
   }
 
-  function getExportText() {
-    return identity.type === IdentityType.V3 ? 'JSON file' : 'the private key string'
-  }
-
   function onCopy() {
-    navigator.clipboard
-      .writeText(identity.identity)
-      .then(() => enqueueSnackbar('Copied to Clipboard', { variant: 'success' }))
+    navigator.clipboard.writeText(exportData).then(() => enqueueSnackbar('Copied to Clipboard', { variant: 'success' }))
   }
 
   return (
@@ -54,10 +51,12 @@ export function ExportFeedDialog({ identity, onClose }: Props): ReactElement {
         <TitleWithClose onClose={onClose}>Export</TitleWithClose>
       </Box>
       <Box mb={2}>
-        <Typography align="center">{`We exported the identity associated with this feed as ${getExportText()}.`}</Typography>
+        <Typography align="center">
+          We exported the identity and feed reference associated with this feed as a JSON file.
+        </Typography>
       </Box>
       <Box mb={4} className={classes.wrapper}>
-        <Code prettify>{identity.identity}</Code>
+        <Code prettify>{exportData}</Code>
       </Box>
       <ExpandableListItemActions>
         <SwarmButton iconType={Download} onClick={onDownload}>

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -49,6 +49,15 @@ export async function convertWalletToIdentity(
   }
 }
 
+export function exportIdentity(identity: Identity): string {
+  return JSON.stringify({
+    type: identity.type,
+    identity: identity.identity,
+    address: identity.address,
+    feedHash: identity.feedHash,
+  })
+}
+
 export async function importIdentity(name: string, data: string): Promise<Identity | null> {
   if (data.length === 64) {
     const wallet = await getWallet(IdentityType.PrivateKey, data)
@@ -68,7 +77,20 @@ export async function importIdentity(name: string, data: string): Promise<Identi
     return { uuid: uuidV4(), name, type: IdentityType.PrivateKey, identity: data, address: wallet.address }
   }
   try {
-    const { address } = JSON.parse(data)
+    const parsed = JSON.parse(data)
+
+    if (typeof parsed.identity === 'string' && typeof parsed.type === 'string' && typeof parsed.address === 'string') {
+      return {
+        uuid: uuidV4(),
+        name,
+        type: parsed.type,
+        identity: parsed.identity,
+        address: parsed.address,
+        feedHash: typeof parsed.feedHash === 'string' ? parsed.feedHash : undefined,
+      }
+    }
+
+    const { address } = parsed
 
     return { uuid: uuidV4(), name, type: IdentityType.V3, identity: data, address }
   } catch {


### PR DESCRIPTION
Changes:

Fix: feed export/import now preserves the feedHash (the reference to the feed's content on Swarm), 
not just the private key. Previously, an exported and re-imported feed always appeared empty, since 
the reference to its attached files/folder/website was lost during export.
